### PR TITLE
Support nested drop targets

### DIFF
--- a/modules/DragDropContext.js
+++ b/modules/DragDropContext.js
@@ -36,7 +36,7 @@ export default class DragDropContext {
     }
 
     const { type: targetType } = targetHandle;
-    const draggedItemType = this.getDraggedItemType();
+    const draggedItemType = this.getItemType();
 
     return targetType === draggedItemType &&
            target.canDrop(this, targetHandle);
@@ -49,7 +49,7 @@ export default class DragDropContext {
     }
 
     const { type: sourceType } = sourceHandle;
-    const draggedItemType = this.getDraggedItemType();
+    const draggedItemType = this.getItemType();
     if (sourceType !== draggedItemType) {
       return false;
     }
@@ -62,16 +62,20 @@ export default class DragDropContext {
     return source.isDragging(this, sourceHandle);
   }
 
-  getDraggedItemType() {
-    return this.dragOperationStore.getDraggedItemType();
+  getItemType() {
+    return this.dragOperationStore.getItemType();
   }
 
-  getDraggedItem() {
-    return this.dragOperationStore.getDraggedItem();
+  getItem() {
+    return this.dragOperationStore.getItem();
   }
 
-  getDraggedSourceHandle() {
-    return this.dragOperationStore.getDraggedSourceHandle();
+  getSourceHandle() {
+    return this.dragOperationStore.getSourceHandle();
+  }
+
+  getTargetHandles() {
+    return this.dragOperationStore.getTargetHandles();
   }
 
   getDropResult() {

--- a/modules/DragDropContext.js
+++ b/modules/DragDropContext.js
@@ -42,10 +42,6 @@ export default class DragDropContext {
            target.canDrop(this);
   }
 
-  canEndDrag() {
-    return this.isDragging();
-  }
-
   isDragging(sourceHandle) {
     const isDragging = this.dragOperationStore.isDragging();
     if (!isDragging || typeof sourceHandle === 'undefined') {

--- a/modules/DragDropContext.js
+++ b/modules/DragDropContext.js
@@ -8,12 +8,10 @@ export default class DragDropContext {
 
   addChangeListener(listener, context) {
     this.dragOperationStore.addListener('change', listener, context);
-    this.registry.addListener('change', listener, context);
   }
 
   removeChangeListener(listener, context) {
     this.dragOperationStore.removeListener('change', listener, context);
-    this.registry.removeListener('change', listener, context);
   }
 
   canDrag(sourceHandle) {

--- a/modules/DragDropContext.js
+++ b/modules/DragDropContext.js
@@ -67,7 +67,7 @@ export default class DragDropContext {
   }
 
   isDraggedSource(source) {
-    return source === this.registry.getPinnedSource();
+    return source === this.registry.getActiveSource();
   }
 
   getDraggedItemType() {

--- a/modules/DragDropManager.js
+++ b/modules/DragDropManager.js
@@ -7,7 +7,7 @@ export default class DragDropManager {
     const flux = new Flux(this);
 
     this.flux = flux;
-    this.registry = new HandlerRegistry(flux);
+    this.registry = new HandlerRegistry(flux.registryActions);
     this.context = new DragDropContext(flux, this.registry);
     this.backend = new Backend(flux.dragDropActions);
   }

--- a/modules/DragDropManager.js
+++ b/modules/DragDropManager.js
@@ -7,7 +7,7 @@ export default class DragDropManager {
     const flux = new Flux(this);
 
     this.flux = flux;
-    this.registry = new HandlerRegistry();
+    this.registry = new HandlerRegistry(flux);
     this.context = new DragDropContext(flux, this.registry);
     this.backend = new Backend(flux.dragDropActions);
   }

--- a/modules/DragSource.js
+++ b/modules/DragSource.js
@@ -4,7 +4,7 @@ export default class DragSource {
   }
 
   isDragging(context, handle) {
-    return handle === context.getDraggedSourceHandle();
+    return handle === context.getSourceHandle();
   }
 
   endDrag() { }

--- a/modules/Flux.js
+++ b/modules/Flux.js
@@ -1,5 +1,6 @@
 import { Flummox } from 'flummox';
 import DragDropActions from './actions/DragDropActions';
+import RegistryActions from './actions/RegistryActions';
 import DragOperationStore from './stores/DragOperationStore';
 
 export default class Flux extends Flummox {
@@ -9,6 +10,10 @@ export default class Flux extends Flummox {
     this.createActions('dragDropActions', DragDropActions, manager);
     this.dragDropActions = this.getActions('dragDropActions');
     this.dragDropActionIds = this.getActionIds('dragDropActions');
+
+    this.createActions('registryActions', RegistryActions);
+    this.registryActions = this.getActions('registryActions');
+    this.registryActionIds = this.getActionIds('registryActions');
 
     this.createStore('dragOperationStore', DragOperationStore, this);
     this.dragOperationStore = this.getStore('dragOperationStore');

--- a/modules/__tests__/DragDropContext-test.js
+++ b/modules/__tests__/DragDropContext-test.js
@@ -36,34 +36,6 @@ describe('DragDropContext', () => {
       context.addChangeListener(done);
       backend.simulateEndDrag();
     });
-
-    it('raises change event when adding a source', (done) => {
-      const source = new NormalSource();
-      context.addChangeListener(done);
-      registry.addSource(Types.FOO, source);
-    });
-
-    it('raises change event when adding a target', (done) => {
-      const target = new NormalTarget();
-      context.addChangeListener(done);
-      registry.addTarget(Types.FOO, target);
-    });
-
-    it('raises change event when removing a source', (done) => {
-      const source = new NormalSource();
-      const sourceHandle = registry.addSource(Types.FOO, source);
-
-      context.addChangeListener(done);
-      registry.removeSource(sourceHandle);
-    });
-
-    it('raises change event when removing a target', (done) => {
-      const target = new NormalTarget();
-      const targetHandle = registry.addTarget(Types.FOO, target);
-
-      context.addChangeListener(done);
-      registry.removeTarget(targetHandle);
-    });
   });
 
   describe('state tracking', () => {

--- a/modules/__tests__/DragDropContext-test.js
+++ b/modules/__tests__/DragDropContext-test.js
@@ -91,7 +91,8 @@ describe('DragDropContext', () => {
       expect(context.canDrag(sourceCHandle)).to.equal(false);
       expect(context.canDrag(sourceDHandle)).to.equal(false);
 
-      backend.simulateDrop(targetHandle);
+      backend.simulateEnter(targetHandle);
+      backend.simulateDrop();
       expect(context.canDrag(sourceAHandle)).to.equal(false);
       expect(context.canDrag(sourceBHandle)).to.equal(false);
       expect(context.canDrag(sourceCHandle)).to.equal(false);
@@ -133,7 +134,8 @@ describe('DragDropContext', () => {
       expect(context.canDrop(targetCHandle)).to.equal(false);
       expect(context.canDrop(targetDHandle)).to.equal(false);
 
-      backend.simulateDrop(targetAHandle);
+      backend.simulateEnter(targetAHandle);
+      backend.simulateDrop();
       expect(context.canDrop(targetAHandle)).to.equal(false);
       expect(context.canDrop(targetBHandle)).to.equal(false);
       expect(context.canDrop(targetCHandle)).to.equal(false);
@@ -171,7 +173,8 @@ describe('DragDropContext', () => {
       expect(context.isDragging(sourceHandle)).to.equal(true);
       expect(context.isDragging(otherHandle)).to.equal(false);
 
-      backend.simulateDrop(targetHandle);
+      backend.simulateEnter(targetHandle);
+      backend.simulateDrop();
       expect(context.canEndDrag()).to.equal(true);
       expect(context.isDragging()).to.equal(true);
       expect(context.isDragging(sourceHandle)).to.equal(true);
@@ -205,7 +208,8 @@ describe('DragDropContext', () => {
       expect(context.getDraggedItem().a).to.equal(123);
       expect(context.getDraggedItemType()).to.equal(Types.FOO);
 
-      backend.simulateDrop(targetHandle);
+      backend.simulateEnter(targetHandle);
+      backend.simulateDrop();
       expect(context.getDraggedItem().a).to.equal(123);
       expect(context.getDraggedItemType()).to.equal(Types.FOO);
 
@@ -233,7 +237,8 @@ describe('DragDropContext', () => {
       expect(context.didDrop()).to.equal(false);
       expect(context.getDropResult()).to.equal(false);
 
-      backend.simulateDrop(targetAHandle);
+      backend.simulateEnter(targetAHandle);
+      backend.simulateDrop();
       expect(context.didDrop()).to.equal(true);
       expect(context.getDropResult().a).to.equal(123);
 
@@ -245,7 +250,8 @@ describe('DragDropContext', () => {
       expect(context.didDrop()).to.equal(false);
       expect(context.getDropResult()).to.equal(false);
 
-      backend.simulateDrop(targetBHandle);
+      backend.simulateEnter(targetBHandle);
+      backend.simulateDrop();
       expect(context.didDrop()).to.equal(true);
       expect(context.getDropResult()).to.equal(true);
 
@@ -289,7 +295,8 @@ describe('DragDropContext', () => {
       expect(context.isDragging(sourceDHandle)).to.equal(true);
 
       registry.removeSource(sourceDHandle);
-      backend.simulateDrop(targetHandle);
+      backend.simulateEnter(targetHandle);
+      backend.simulateDrop();
       expect(context.isDragging(sourceAHandle)).to.equal(false);
       expect(context.isDragging(sourceBHandle)).to.equal(true);
       expect(context.isDragging(sourceCHandle)).to.equal(false);

--- a/modules/__tests__/DragDropContext-test.js
+++ b/modules/__tests__/DragDropContext-test.js
@@ -153,7 +153,7 @@ describe('DragDropContext', () => {
       expect(context.canDrop(targetDHandle)).to.equal(false);
     });
 
-    it('returns true from canEndDrag and isDragging only while dragging', () => {
+    it('returns true from isDragging only while dragging', () => {
       const source = new NormalSource();
       const sourceHandle = registry.addSource(Types.FOO, source);
       const other = new NormalSource();
@@ -161,32 +161,27 @@ describe('DragDropContext', () => {
       const target = new NormalTarget();
       const targetHandle = registry.addTarget(Types.FOO, target);
 
-      expect(context.canEndDrag()).to.equal(false);
       expect(context.isDragging()).to.equal(false);
       expect(context.isDragging(sourceHandle)).to.equal(false);
       expect(context.isDragging(otherHandle)).to.equal(false);
 
       backend.simulateBeginDrag(sourceHandle);
-      expect(context.canEndDrag()).to.equal(true);
       expect(context.isDragging()).to.equal(true);
       expect(context.isDragging(sourceHandle)).to.equal(true);
       expect(context.isDragging(otherHandle)).to.equal(false);
 
       backend.simulateEnter(targetHandle);
       backend.simulateDrop();
-      expect(context.canEndDrag()).to.equal(true);
       expect(context.isDragging()).to.equal(true);
       expect(context.isDragging(sourceHandle)).to.equal(true);
       expect(context.isDragging(otherHandle)).to.equal(false);
 
       backend.simulateEndDrag();
-      expect(context.canEndDrag()).to.equal(false);
       expect(context.isDragging()).to.equal(false);
       expect(context.isDragging(sourceHandle)).to.equal(false);
       expect(context.isDragging(otherHandle)).to.equal(false);
 
       backend.simulateBeginDrag(otherHandle);
-      expect(context.canEndDrag()).to.equal(true);
       expect(context.isDragging()).to.equal(true);
       expect(context.isDragging(sourceHandle)).to.equal(false);
       expect(context.isDragging(otherHandle)).to.equal(true);

--- a/modules/__tests__/DragDropContext-test.js
+++ b/modules/__tests__/DragDropContext-test.js
@@ -195,31 +195,31 @@ describe('DragDropContext', () => {
       const target = new NormalTarget();
       const targetHandle = registry.addTarget(Types.FOO, target);
 
-      expect(context.getDraggedItem()).to.equal(null);
-      expect(context.getDraggedItemType()).to.equal(null);
-      expect(context.getDraggedSourceHandle()).to.equal(null);
+      expect(context.getItem()).to.equal(null);
+      expect(context.getItemType()).to.equal(null);
+      expect(context.getSourceHandle()).to.equal(null);
 
       backend.simulateBeginDrag(sourceAHandle);
-      expect(context.getDraggedItem().a).to.equal(123);
-      expect(context.getDraggedItemType()).to.equal(Types.FOO);
-      expect(context.getDraggedSourceHandle()).to.equal(sourceAHandle);
+      expect(context.getItem().a).to.equal(123);
+      expect(context.getItemType()).to.equal(Types.FOO);
+      expect(context.getSourceHandle()).to.equal(sourceAHandle);
 
       backend.simulateEnter(targetHandle);
       backend.simulateDrop();
-      expect(context.getDraggedItem().a).to.equal(123);
-      expect(context.getDraggedItemType()).to.equal(Types.FOO);
-      expect(context.getDraggedSourceHandle()).to.equal(sourceAHandle);
+      expect(context.getItem().a).to.equal(123);
+      expect(context.getItemType()).to.equal(Types.FOO);
+      expect(context.getSourceHandle()).to.equal(sourceAHandle);
 
       backend.simulateEndDrag();
-      expect(context.getDraggedItem()).to.equal(null);
-      expect(context.getDraggedItemType()).to.equal(null);
-      expect(context.getDraggedSourceHandle()).to.equal(null);
+      expect(context.getItem()).to.equal(null);
+      expect(context.getItemType()).to.equal(null);
+      expect(context.getSourceHandle()).to.equal(null);
 
       backend.simulateBeginDrag(sourceBHandle);
       registry.removeSource(sourceBHandle);
-      expect(context.getDraggedItem().a).to.equal(456);
-      expect(context.getDraggedItemType()).to.equal(Types.BAR);
-      expect(context.getDraggedSourceHandle()).to.equal(sourceBHandle);
+      expect(context.getItem().a).to.equal(456);
+      expect(context.getItemType()).to.equal(Types.BAR);
+      expect(context.getSourceHandle()).to.equal(sourceBHandle);
     });
 
     it('keeps track of drop result and whether it occured', () => {

--- a/modules/__tests__/DragDropManager-test.js
+++ b/modules/__tests__/DragDropManager-test.js
@@ -115,6 +115,7 @@ describe('DragDropManager', () => {
       backend.simulateEnter(targetHandle);
       backend.simulateDrop();
       backend.simulateEndDrag();
+      expect(target.didCallDrop).to.equal(true);
       expect(source.recordedDropResult.foo).to.equal('bar');
     });
 
@@ -158,14 +159,16 @@ describe('DragDropManager', () => {
       expect(() => backend.simulateEndDrag(sourceHandle)).to.throwError();
     });
 
-    it.skip('throws in drop() if canDrop() returns false', () => {
+    it('ignores drop() if canDrop() returns false', () => {
       const source = new NormalSource();
       const sourceHandle = registry.addSource(Types.FOO, source);
       const target = new NonDroppableTarget();
       const targetHandle = registry.addTarget(Types.FOO, target);
 
       backend.simulateBeginDrag(sourceHandle);
-      expect(() => backend.simulateDrop(targetHandle)).to.throwError();
+      backend.simulateEnter(targetHandle);
+      backend.simulateDrop();
+      expect(target.didCallDrop).to.equal(false);
     });
 
     it.skip('throws in drop() if it is called outside a drag operation', () => {

--- a/modules/__tests__/DragDropManager-test.js
+++ b/modules/__tests__/DragDropManager-test.js
@@ -104,7 +104,8 @@ describe('DragDropManager', () => {
       const targetHandle = registry.addTarget(Types.FOO, target);
 
       backend.simulateBeginDrag(sourceHandle);
-      backend.simulateDrop(targetHandle);
+      backend.simulateEnter(targetHandle);
+      backend.simulateDrop();
       backend.simulateEndDrag();
       expect(source.recordedDropResult.foo).to.equal('bar');
     });
@@ -116,7 +117,8 @@ describe('DragDropManager', () => {
       const targetHandle = registry.addTarget(Types.FOO, target);
 
       backend.simulateBeginDrag(sourceHandle);
-      backend.simulateDrop(targetHandle);
+      backend.simulateEnter(targetHandle);
+      backend.simulateDrop();
       backend.simulateEndDrag();
       expect(source.recordedDropResult).to.equal(true);
     });
@@ -148,7 +150,7 @@ describe('DragDropManager', () => {
       expect(() => backend.simulateEndDrag(sourceHandle)).to.throwError();
     });
 
-    it('throws in drop() if canDrop() returns false', () => {
+    it.skip('throws in drop() if canDrop() returns false', () => {
       const source = new NormalSource();
       const sourceHandle = registry.addSource(Types.FOO, source);
       const target = new NonDroppableTarget();
@@ -158,13 +160,13 @@ describe('DragDropManager', () => {
       expect(() => backend.simulateDrop(targetHandle)).to.throwError();
     });
 
-    it('throws in drop() if it is called outside a drag operation', () => {
+    it.skip('throws in drop() if it is called outside a drag operation', () => {
       const target = new NormalTarget();
       const targetHandle = registry.addTarget(Types.BAR, target);
       expect(() => backend.simulateDrop(targetHandle)).to.throwError();
     });
 
-    it('throws in drop() if target has a different type', () => {
+    it.skip('throws in drop() if target has a different type', () => {
       const source = new NormalSource();
       const sourceHandle = registry.addSource(Types.FOO, source);
       const target = new NormalTarget();
@@ -174,7 +176,7 @@ describe('DragDropManager', () => {
       expect(() => backend.simulateDrop(targetHandle)).to.throwError();
     });
 
-    it('throws if drop() returns something that is neither undefined nor an object', () => {
+    it.skip('throws if drop() returns something that is neither undefined nor an object', () => {
       const source = new NormalSource();
       const sourceHandle = registry.addSource(Types.FOO, source);
       const target = new BadResultTarget();

--- a/modules/__tests__/DragDropManager-test.js
+++ b/modules/__tests__/DragDropManager-test.js
@@ -171,6 +171,16 @@ describe('DragDropManager', () => {
       expect(() => backend.simulateLeave(targetHandle)).to.throwError();
     });
 
+    it('ignores drop() if no drop targets entered', () => {
+      const source = new NormalSource();
+      const sourceHandle = registry.addSource(Types.FOO, source);
+
+      backend.simulateBeginDrag(sourceHandle);
+      backend.simulateDrop();
+      backend.simulateEndDrag();
+      expect(source.recordedDropResult).to.equal(false);
+    });
+
     it('ignores drop() if canDrop() returns false', () => {
       const source = new NormalSource();
       const sourceHandle = registry.addSource(Types.FOO, source);
@@ -196,7 +206,6 @@ describe('DragDropManager', () => {
     });
 
     it('throws in drop() if it is called outside a drag operation', () => {
-      const target = new NormalTarget();
       expect(() => backend.simulateDrop()).to.throwError();
     });
 

--- a/modules/__tests__/DragDropManager-test.js
+++ b/modules/__tests__/DragDropManager-test.js
@@ -62,22 +62,27 @@ describe('DragDropManager', () => {
   });
 
   describe('drag source and target contract', () => {
-    it('throws in beginDrag() if canDrag() returns false', () => {
+    it('ignores beginDrag() if canDrag() returns false', () => {
       const source = new NonDraggableSource();
       const sourceHandle = registry.addSource(Types.FOO, source);
-      expect(() => backend.simulateBeginDrag(sourceHandle)).to.throwError();
+
+      backend.simulateBeginDrag(sourceHandle);
+      expect(source.didCallBeginDrag).to.equal(false);
     });
 
     it('throws if beginDrag() returns non-object', () => {
       const source = new BadItemSource();
       const sourceHandle = registry.addSource(Types.FOO, source);
+
       expect(() => backend.simulateBeginDrag(sourceHandle)).to.throwError();
     });
 
     it('begins drag if canDrag() returns true', () => {
       const source = new NormalSource();
       const sourceHandle = registry.addSource(Types.FOO, source);
-      expect(() => backend.simulateBeginDrag(sourceHandle)).to.not.throwError();
+
+      backend.simulateBeginDrag(sourceHandle);
+      expect(source.didCallBeginDrag).to.equal(true);
     });
 
     it('throws in beginDrag() if it is called twice during one operation', () => {
@@ -94,7 +99,10 @@ describe('DragDropManager', () => {
 
       backend.simulateBeginDrag(sourceHandle);
       backend.simulateEndDrag(sourceHandle);
+
+      source.didCallBeginDrag = false;
       expect(() => backend.simulateBeginDrag(sourceHandle)).to.not.throwError();
+      expect(source.didCallBeginDrag).to.equal(true);
     });
 
     it('endDrag() sees drop() return value as drop result if dropped on a target', () => {

--- a/modules/__tests__/DragDropManager-test.js
+++ b/modules/__tests__/DragDropManager-test.js
@@ -159,6 +159,18 @@ describe('DragDropManager', () => {
       expect(() => backend.simulateEndDrag(sourceHandle)).to.throwError();
     });
 
+    it('throws in enter() if it is called outside a drag operation', () => {
+      const target = new NormalTarget();
+      const targetHandle = registry.addTarget(Types.BAR, target);
+      expect(() => backend.simulateEnter(targetHandle)).to.throwError();
+    });
+
+    it('throws in leave() if it is called outside a drag operation', () => {
+      const target = new NormalTarget();
+      const targetHandle = registry.addTarget(Types.BAR, target);
+      expect(() => backend.simulateLeave(targetHandle)).to.throwError();
+    });
+
     it('ignores drop() if canDrop() returns false', () => {
       const source = new NormalSource();
       const sourceHandle = registry.addSource(Types.FOO, source);
@@ -171,30 +183,32 @@ describe('DragDropManager', () => {
       expect(target.didCallDrop).to.equal(false);
     });
 
-    it.skip('throws in drop() if it is called outside a drag operation', () => {
-      const target = new NormalTarget();
-      const targetHandle = registry.addTarget(Types.BAR, target);
-      expect(() => backend.simulateDrop(targetHandle)).to.throwError();
-    });
-
-    it.skip('throws in drop() if target has a different type', () => {
+    it('ignores drop() if target has a different type', () => {
       const source = new NormalSource();
       const sourceHandle = registry.addSource(Types.FOO, source);
       const target = new NormalTarget();
       const targetHandle = registry.addTarget(Types.BAR, target);
 
       backend.simulateBeginDrag(sourceHandle);
-      expect(() => backend.simulateDrop(targetHandle)).to.throwError();
+      backend.simulateEnter(targetHandle);
+      backend.simulateDrop();
+      expect(target.didCallDrop).to.equal(false);
     });
 
-    it.skip('throws if drop() returns something that is neither undefined nor an object', () => {
+    it('throws in drop() if it is called outside a drag operation', () => {
+      const target = new NormalTarget();
+      expect(() => backend.simulateDrop()).to.throwError();
+    });
+
+    it('throws in drop() if it returns something that is neither undefined nor an object', () => {
       const source = new NormalSource();
       const sourceHandle = registry.addSource(Types.FOO, source);
       const target = new BadResultTarget();
       const targetHandle = registry.addTarget(Types.FOO, target);
 
       backend.simulateBeginDrag(sourceHandle);
-      expect(() => backend.simulateDrop(targetHandle)).to.throwError();
+      backend.simulateEnter(targetHandle);
+      expect(() => backend.simulateDrop()).to.throwError();
     });
   });
 });

--- a/modules/__tests__/DragDropManager-test.js
+++ b/modules/__tests__/DragDropManager-test.js
@@ -181,6 +181,26 @@ describe('DragDropManager', () => {
       expect(source.recordedDropResult).to.equal(false);
     });
 
+    it('ignores drop() if drop targets entered and left', () => {
+      const source = new NormalSource();
+      const sourceHandle = registry.addSource(Types.FOO, source);
+      const targetA = new NormalTarget();
+      const targetAHandle = registry.addTarget(Types.FOO, targetA);
+      const targetB = new NormalTarget();
+      const targetBHandle = registry.addTarget(Types.FOO, targetB);
+
+      backend.simulateBeginDrag(sourceHandle);
+      backend.simulateEnter(targetAHandle);
+      backend.simulateEnter(targetBHandle);
+      backend.simulateLeave(targetBHandle);
+      backend.simulateLeave(targetAHandle);
+      backend.simulateDrop();
+      backend.simulateEndDrag();
+      expect(targetA.didCallDrop).to.equal(false);
+      expect(targetB.didCallDrop).to.equal(false);
+      expect(source.recordedDropResult).to.equal(false);
+    });
+
     it('ignores drop() if canDrop() returns false', () => {
       const source = new NormalSource();
       const sourceHandle = registry.addSource(Types.FOO, source);

--- a/modules/__tests__/sources.js
+++ b/modules/__tests__/sources.js
@@ -3,9 +3,11 @@ import { DragSource } from '..';
 export class NormalSource extends DragSource {
   constructor(item) {
     this.item = item || { baz: 42 };
+    this.didCallBeginDrag = false;
   }
 
   beginDrag() {
+    this.didCallBeginDrag = true;
     return this.item;
   }
 
@@ -15,11 +17,16 @@ export class NormalSource extends DragSource {
 }
 
 export class NonDraggableSource extends DragSource {
+  constructor() {
+    this.didCallBeginDrag = false;
+  }
+
   canDrag() {
     return false;
   }
 
   beginDrag() {
+    this.didCallBeginDrag = true;
     return {};
   }
 }

--- a/modules/__tests__/sources.js
+++ b/modules/__tests__/sources.js
@@ -48,7 +48,7 @@ export class NumberSource extends DragSource {
   }
 
   isDragging(context) {
-    const item = context.getDraggedItem();
+    const item = context.getItem();
     return item.number === this.number;
   }
 

--- a/modules/__tests__/targets.js
+++ b/modules/__tests__/targets.js
@@ -2,17 +2,27 @@ import { DropTarget } from '..';
 
 export class NormalTarget extends DropTarget {
   constructor(dropResult) {
+    this.didCallDrop = false;
     this.dropResult = dropResult || { foo: 'bar' };
   }
 
   drop() {
+    this.didCallDrop = true;
     return this.dropResult;
   }
 }
 
 export class NonDroppableTarget extends DropTarget {
+  constructor() {
+    this.didCallDrop = false;
+  }
+
   canDrop() {
     return false;
+  }
+
+  drop() {
+    this.didCallDrop = true;
   }
 }
 

--- a/modules/actions/DragDropActions.js
+++ b/modules/actions/DragDropActions.js
@@ -11,9 +11,12 @@ export default class DragDropActions extends Actions {
   beginDrag(sourceHandle) {
     const { context, registry } = this.manager;
     invariant(
-      context.canDrag(sourceHandle),
-      'Cannot call beginDrag now. Check context.canDrag(sourceHandle) first.'
+      !context.isDragging(),
+      'Cannot call beginDrag while dragging.'
     );
+    if (!context.canDrag(sourceHandle)) {
+      return;
+    }
 
     const source = registry.getSource(sourceHandle);
     const item = source.beginDrag(context);
@@ -66,8 +69,8 @@ export default class DragDropActions extends Actions {
   endDrag() {
     const { context, registry } = this.manager;
     invariant(
-      context.canEndDrag(),
-      'Cannot call endDrag now. Check context.canEndDrag() first.'
+      context.isDragging(),
+      'Cannot call endDrag while not dragging.'
     );
 
     const source = registry.getActiveSource();

--- a/modules/actions/DragDropActions.js
+++ b/modules/actions/DragDropActions.js
@@ -39,17 +39,19 @@ export default class DragDropActions extends Actions {
 
   drop() {
     const { context, registry } = this.manager;
-    const targetHandles = registry.getActiveTargetHandles();
     invariant(
-      targetHandles.length > 0,
-      'Cannot call drop before any targets have entered.'
+      context.isDragging(),
+      'Cannot call drop while not dragging.'
     );
 
+    const targetHandles = registry.getActiveTargetHandles();
+    if (!targetHandles.length) {
+      return;
+    }
     const targetHandle = targetHandles[targetHandles.length - 1];
-    invariant(
-      context.canDrop(targetHandle),
-      'Cannot call drop now. Check context.canDrop(targetHandle) first.'
-    );
+    if (!context.canDrop(targetHandle)) {
+      return;
+    }
 
     const target = registry.getTarget(targetHandle);
     let dropResult = target.drop(context);

--- a/modules/actions/DragDropActions.js
+++ b/modules/actions/DragDropActions.js
@@ -30,6 +30,11 @@ export default class DragDropActions extends Actions {
 
   enter(targetHandle) {
     const { context } = this.manager;
+    invariant(
+      context.isDragging(),
+      'Cannot call enter while not dragging.'
+    );
+
     const targetHandles = context.getTargetHandles();
     invariant(
       targetHandles.indexOf(targetHandle) === -1,
@@ -41,6 +46,11 @@ export default class DragDropActions extends Actions {
 
   leave(targetHandle) {
     const { context } = this.manager;
+    invariant(
+      context.isDragging(),
+      'Cannot call leave while not dragging.'
+    );
+
     const targetHandles = context.getTargetHandles();
     invariant(
       targetHandles.indexOf(targetHandle) !== -1,

--- a/modules/actions/DragDropActions.js
+++ b/modules/actions/DragDropActions.js
@@ -19,20 +19,36 @@ export default class DragDropActions extends Actions {
     const item = source.beginDrag(context);
     invariant(isObject(item), 'Item must be an object.');
 
-    registry.pinSource(sourceHandle);
+    registry.setActiveSource(sourceHandle);
     const { type: itemType } = sourceHandle;
     return { itemType, item, sourceHandle };
   }
 
-  drop(targetHandle) {
+  enter(targetHandle) {
+    const { registry } = this.manager;
+    registry.pushActiveTarget(targetHandle);
+  }
+
+  leave(targetHandle) {
+    const { registry } = this.manager;
+    registry.popActiveTarget(targetHandle);
+  }
+
+  drop() {
     const { context, registry } = this.manager;
+    const targetHandles = registry.getActiveTargetHandles();
+    invariant(
+      targetHandles.length > 0,
+      'Cannot call drop before any targets have entered.'
+    );
+
+    const targetHandle = targetHandles[targetHandles.length - 1];
     invariant(
       context.canDrop(targetHandle),
       'Cannot call drop now. Check context.canDrop(targetHandle) first.'
     );
 
     const target = registry.getTarget(targetHandle);
-
     let dropResult = target.drop(context);
     invariant(
       typeof dropResult === 'undefined' || isObject(dropResult),
@@ -41,6 +57,8 @@ export default class DragDropActions extends Actions {
     if (typeof dropResult === 'undefined') {
       dropResult = true;
     }
+
+    registry.clearActiveTarget();
 
     return { dropResult };
   }
@@ -52,9 +70,11 @@ export default class DragDropActions extends Actions {
       'Cannot call endDrag now. Check context.canEndDrag() first.'
     );
 
-    const source = registry.getPinnedSource();
+    const source = registry.getActiveSource();
     source.endDrag(context);
-    registry.unpinSource();
+
+    registry.clearActiveSource();
+    registry.clearActiveTarget();
 
     return {};
   }

--- a/modules/actions/RegistryActions.js
+++ b/modules/actions/RegistryActions.js
@@ -1,0 +1,19 @@
+import { Actions } from 'flummox'
+
+export default class RegistryActions extends Actions {
+  addSource({ sourceHandle }) {
+    return { sourceHandle };
+  }
+
+  addTarget({ targetHandle }) {
+    return { targetHandle };
+  }
+
+  removeSource({ sourceHandle }) {
+    return { sourceHandle };
+  }
+
+  removeTarget({ targetHandle }) {
+    return { targetHandle };
+  }
+}

--- a/modules/backends/TestBackend.js
+++ b/modules/backends/TestBackend.js
@@ -7,8 +7,16 @@ export default class TestBackend {
     this.actions.beginDrag(sourceHandle);
   }
 
-  simulateDrop(targetHandle) {
-    this.actions.drop(targetHandle);
+  simulateEnter(targetHandle) {
+    this.actions.enter(targetHandle);
+  }
+
+  simulateLeave(targetHandle) {
+    this.actions.leave(targetHandle);
+  }
+
+  simulateDrop() {
+    this.actions.drop();
   }
 
   simulateEndDrag() {

--- a/modules/stores/DragOperationStore.js
+++ b/modules/stores/DragOperationStore.js
@@ -6,13 +6,16 @@ export default class DragOperationStore extends Store {
 
     const { dragDropActionIds } = flux;
     this.register(dragDropActionIds.beginDrag, this.handleBeginDrag);
+    this.register(dragDropActionIds.enter, this.handleEnter);
+    this.register(dragDropActionIds.leave, this.handleLeave);
     this.register(dragDropActionIds.endDrag, this.handleEndDrag);
     this.register(dragDropActionIds.drop, this.handleDrop);
 
     this.state = {
-      draggedItemType: null,
-      draggedItem: null,
-      draggedSourceHandle: null,
+      itemType: null,
+      item: null,
+      sourceHandle: null,
+      targetHandles: [],
       dropResult: null,
       didDrop: false
     };
@@ -20,45 +23,68 @@ export default class DragOperationStore extends Store {
 
   handleBeginDrag({ itemType, item, sourceHandle }) {
     this.setState({
-      draggedItemType: itemType,
-      draggedItem: item,
-      draggedSourceHandle: sourceHandle,
+      itemType,
+      item,
+      sourceHandle,
+      targetHandles: [],
       dropResult: false,
       didDrop: false
+    });
+  }
+
+  handleEnter({ targetHandle }) {
+    const { targetHandles } = this.state;
+    this.setState({
+      targetHandles: targetHandles.concat([targetHandle])
+    });
+  }
+
+  handleLeave({ targetHandle }) {
+    const { targetHandles } = this.state;
+    const index = targetHandles.indexOf(targetHandle);
+
+    this.setState({
+      targetHandles: targetHandles.slice(0, index)
     });
   }
 
   handleDrop({ dropResult }) {
     this.setState({
       dropResult,
-      didDrop: true
+      didDrop: true,
+      targetHandles: []
     });
   }
 
   handleEndDrag() {
     this.setState({
-      draggedItemType: null,
-      draggedItem: null,
-      draggedSourceHandle: null,
+      itemType: null,
+      item: null,
+      sourceHandle: null,
+      targetHandles: [],
       dropResult: null,
       didDrop: false
     });
   }
 
   isDragging() {
-    return Boolean(this.getDraggedItemType());
+    return Boolean(this.getItemType());
   }
 
-  getDraggedItemType() {
-    return this.state.draggedItemType;
+  getItemType() {
+    return this.state.itemType;
   }
 
-  getDraggedSourceHandle() {
-    return this.state.draggedSourceHandle;
+  getSourceHandle() {
+    return this.state.sourceHandle;
   }
 
-  getDraggedItem() {
-    return this.state.draggedItem;
+  getTargetHandles() {
+    return this.state.targetHandles;
+  }
+
+  getItem() {
+    return this.state.item;
   }
 
   getDropResult() {

--- a/modules/stores/DragOperationStore.js
+++ b/modules/stores/DragOperationStore.js
@@ -4,12 +4,13 @@ export default class DragOperationStore extends Store {
   constructor(flux) {
     super();
 
-    const { dragDropActionIds } = flux;
+    const { dragDropActionIds, registryActionIds } = flux;
     this.register(dragDropActionIds.beginDrag, this.handleBeginDrag);
     this.register(dragDropActionIds.enter, this.handleEnter);
     this.register(dragDropActionIds.leave, this.handleLeave);
     this.register(dragDropActionIds.endDrag, this.handleEndDrag);
     this.register(dragDropActionIds.drop, this.handleDrop);
+    this.register(registryActionIds.removeTarget, this.handleRemoveTarget);
 
     this.state = {
       itemType: null,
@@ -46,6 +47,12 @@ export default class DragOperationStore extends Store {
     this.setState({
       targetHandles: targetHandles.slice(0, index)
     });
+  }
+
+  handleRemoveTarget({ targetHandle }) {
+    if (this.getTargetHandles().indexOf(targetHandle) > -1) {
+      this.handleLeave({ targetHandle });
+    }
   }
 
   handleDrop({ dropResult }) {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "mocha": "^2.0.1"
   },
   "dependencies": {
-    "eventemitter3": "^0.1.6",
     "flummox": "^2.13.0",
     "invariant": "^2.0.0",
     "keymirror": "^0.1.1",


### PR DESCRIPTION
TODO:

- [x] https://github.com/gaearon/dnd-core/commit/55f2e379e5bb686b6adbb16765bfc3314f1619c8 <s>Barebone `enter`, `leave`, single-target `drop` implementation</s>
- [x] <s>Don't throw when drag/drop is requested but not allowed (See [this comment](https://github.com/gaearon/dnd-core/pull/3#issuecomment-77694663) for rationale):</s>
  - [x] https://github.com/gaearon/dnd-core/commit/ac90b770ae43d18a15cb5aa8700f699db6df5f66 <s>If `canDrag` is `false`, instead of throwing in `beginDrag`, silently return. Test that.</s>
  - [x] https://github.com/gaearon/dnd-core/commit/d157cba0ce6f9a1d2d62d5ca48d56bcf3eb27931 <s>If `canDrop` is `false`, instead of throwing in `drop`, silently return. Test that.</s>
  - [x] https://github.com/gaearon/dnd-core/commit/f7f6f36af2c2656d11940a30c5366bb805a6e417 <s>Throw in `enter` and `leave`, `drop` if we're not currently dragging (Amend skipped tests.)</s>
- [x] https://github.com/gaearon/dnd-core/commit/bf2c3b69444614ab50b7658d4ce860e6c12ab2de https://github.com/gaearon/dnd-core/commit/ae1701eea88c83f769cae6db1c7d4a2b50390016 <s>If no drop targets `enter`ed, change `drop` to do nothing instead of throwing. Test that.</s>
- [ ] Add test verifying `enter` throws with an already `enter`ed drop target
- [ ] Add test verifying `leave` throws with a non-`enter`ed drop target
- [ ] Add test verifying `enter` A, B, C, D and `leave` B keeps A active, but B, C and D inactive
- [ ] Add test verifying that removing an `enter`ed drop target midflight has the same effect as calling `leave` on it
- [ ] Add test verifying both `drop` and `endDrag` completely clear active drop targets
- [ ] Add and test `context.isOver(dropTarget, shallow=false)` that tells whether we have entered the drop target. With `shallow=true`, returns `true` *only* if that drop target is innermost entered one.
- [ ] Change `drop` implementation that, instead of simply choosing innermost target, will run `drop` on each nested active target, from the innermost to the outermost. It will skip drop targets for which `context.canDrop` returns false. Each target will be able to access previous' result in `context.getDropResult()` and learn if there *was* a previous one by reading `context.didDrop()`. Each will be able to either return `undefined` (means don't touch drop result) or a different object (means replace drop result with the one returned from `drop`). Test that.