### PR TITLE
Nesting: part 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,4 @@ All of this should be easy to implement in React DnD (and any other library usin
 [Tests](https://github.com/gaearon/dnd-core/tree/master/modules/__tests__) should give you some idea. You register drag sources and drop targets, hook up a backend (you can use barebone `TestBackend` or implement a fancy real one yourself), and your drag sources and drop targets magically begin to interact.
 
 ![](http://i.imgur.com/NzjAu8a.png)
+

--- a/modules/DragDropContext.js
+++ b/modules/DragDropContext.js
@@ -60,6 +60,20 @@ export default class DragDropContext {
     return source.isDragging(this, sourceHandle);
   }
 
+  isOver(targetHandle, shallow = false) {
+    const targetHandles = this.getTargetHandles();
+    if (!targetHandles.length) {
+      return false;
+    }
+
+    const index = targetHandles.indexOf(targetHandle);
+    if (shallow) {
+      return index === targetHandles.length - 1;
+    } else {
+      return index > -1;
+    }
+  }
+
   getItemType() {
     return this.dragOperationStore.getItemType();
   }

--- a/modules/__tests__/DragDropContext-test.js
+++ b/modules/__tests__/DragDropContext-test.js
@@ -233,6 +233,53 @@ describe('DragDropContext', () => {
     });
   });
 
+  describe('enter and leave', () => {
+    it('treats removing an entered drop target midflight as calling leave() on it', () => {
+      const source = new NormalSource();
+      const sourceHandle = registry.addSource(Types.FOO, source);
+      const target = new NormalTarget();
+      const targetHandle = registry.addTarget(Types.FOO, target);
+
+      backend.simulateBeginDrag(sourceHandle);
+      backend.simulateEnter(targetHandle);
+      expect(context.getTargetHandles().length).to.be(1);
+
+      registry.removeTarget(targetHandle);
+      expect(context.getTargetHandles().length).to.be(0);
+    });
+
+    it('leaves nested drop zones when parent leaves', () => {
+      const source = new NormalSource();
+      const sourceHandle = registry.addSource(Types.FOO, source);
+      const targetA = new NormalTarget();
+      const targetAHandle = registry.addTarget(Types.FOO, targetA);
+      const targetB = new NormalTarget();
+      const targetBHandle = registry.addTarget(Types.FOO, targetB);
+      const targetC = new NormalTarget();
+      const targetCHandle = registry.addTarget(Types.BAR, targetC);
+      const targetD = new NormalTarget();
+      const targetDHandle = registry.addTarget(Types.FOO, targetD);
+      let handles;
+
+      backend.simulateBeginDrag(sourceHandle);
+      backend.simulateEnter(targetAHandle);
+      backend.simulateEnter(targetBHandle);
+      backend.simulateEnter(targetCHandle);
+      backend.simulateEnter(targetDHandle);
+      handles = context.getTargetHandles();
+      expect(handles.length).to.be(4);
+      expect(handles[0]).to.equal(targetAHandle);
+      expect(handles[1]).to.equal(targetBHandle);
+      expect(handles[2]).to.equal(targetCHandle);
+      expect(handles[3]).to.equal(targetDHandle);
+
+      backend.simulateLeave(targetBHandle);
+      handles = context.getTargetHandles();
+      expect(handles[0]).to.equal(targetAHandle);
+      expect(handles.length).to.be(1);
+    });
+  });
+
   describe('mirror drag sources', () => {
     it('uses custom isDragging functions', () => {
       const sourceA = new NumberSource(1, true);

--- a/modules/__tests__/DragDropContext-test.js
+++ b/modules/__tests__/DragDropContext-test.js
@@ -243,9 +243,13 @@ describe('DragDropContext', () => {
       backend.simulateBeginDrag(sourceHandle);
       backend.simulateEnter(targetHandle);
       expect(context.getTargetHandles().length).to.be(1);
+      expect(context.isOver(targetHandle)).to.equal(true);
+      expect(context.isOver(targetHandle, true)).to.equal(true);
 
       registry.removeTarget(targetHandle);
       expect(context.getTargetHandles().length).to.be(0);
+      expect(context.isOver(targetHandle)).to.equal(false);
+      expect(context.isOver(targetHandle, true)).to.equal(false);
     });
 
     it('leaves nested drop zones when parent leaves', () => {
@@ -264,19 +268,38 @@ describe('DragDropContext', () => {
       backend.simulateBeginDrag(sourceHandle);
       backend.simulateEnter(targetAHandle);
       backend.simulateEnter(targetBHandle);
+      handles = context.getTargetHandles();
+      expect(handles.length).to.be(2);
+      expect(handles[0]).to.equal(targetAHandle);
+      expect(context.isOver(targetAHandle)).to.equal(true);
+      expect(context.isOver(targetAHandle, true)).to.equal(false);
+      expect(handles[1]).to.equal(targetBHandle);
+      expect(context.isOver(targetBHandle)).to.equal(true);
+      expect(context.isOver(targetBHandle, true)).to.equal(true);
+
       backend.simulateEnter(targetCHandle);
       backend.simulateEnter(targetDHandle);
       handles = context.getTargetHandles();
       expect(handles.length).to.be(4);
       expect(handles[0]).to.equal(targetAHandle);
+      expect(context.isOver(targetAHandle)).to.equal(true);
+      expect(context.isOver(targetAHandle, true)).to.equal(false);
       expect(handles[1]).to.equal(targetBHandle);
+      expect(context.isOver(targetBHandle)).to.equal(true);
+      expect(context.isOver(targetBHandle, true)).to.equal(false);
       expect(handles[2]).to.equal(targetCHandle);
+      expect(context.isOver(targetCHandle)).to.equal(true);
+      expect(context.isOver(targetCHandle, true)).to.equal(false);
       expect(handles[3]).to.equal(targetDHandle);
+      expect(context.isOver(targetDHandle)).to.equal(true);
+      expect(context.isOver(targetDHandle, true)).to.equal(true);
 
       backend.simulateLeave(targetBHandle);
       handles = context.getTargetHandles();
       expect(handles[0]).to.equal(targetAHandle);
       expect(handles.length).to.be(1);
+      expect(context.isOver(targetAHandle)).to.equal(true);
+      expect(context.isOver(targetAHandle, true)).to.equal(true);
     });
 
     it('reset target handles on drop', () => {
@@ -296,12 +319,20 @@ describe('DragDropContext', () => {
       backend.simulateEnter(targetBHandle);
       handles = context.getTargetHandles();
       expect(handles[0]).to.equal(targetAHandle);
+      expect(context.isOver(targetAHandle)).to.equal(true);
+      expect(context.isOver(targetAHandle, true)).to.equal(false);
       expect(handles[1]).to.equal(targetBHandle);
+      expect(context.isOver(targetBHandle)).to.equal(true);
+      expect(context.isOver(targetBHandle, true)).to.equal(true);
       expect(handles.length).to.be(2);
 
       backend.simulateDrop();
       handles = context.getTargetHandles();
       expect(handles.length).to.be(0);
+      expect(context.isOver(targetAHandle)).to.equal(false);
+      expect(context.isOver(targetAHandle, true)).to.equal(false);
+      expect(context.isOver(targetBHandle)).to.equal(false);
+      expect(context.isOver(targetBHandle, true)).to.equal(false);
 
       backend.simulateEndDrag();
       handles = context.getTargetHandles();
@@ -311,6 +342,8 @@ describe('DragDropContext', () => {
       backend.simulateEnter(targetAHandle);
       handles = context.getTargetHandles();
       expect(handles[0]).to.equal(targetAHandle);
+      expect(context.isOver(targetAHandle)).to.equal(true);
+      expect(context.isOver(targetAHandle, true)).to.equal(true);
       expect(handles.length).to.be(1);
     });
 

--- a/modules/__tests__/DragDropContext-test.js
+++ b/modules/__tests__/DragDropContext-test.js
@@ -233,7 +233,7 @@ describe('DragDropContext', () => {
     });
   });
 
-  describe('enter and leave', () => {
+  describe('target handle tracking', () => {
     it('treats removing an entered drop target midflight as calling leave() on it', () => {
       const source = new NormalSource();
       const sourceHandle = registry.addSource(Types.FOO, source);
@@ -274,6 +274,72 @@ describe('DragDropContext', () => {
       expect(handles[3]).to.equal(targetDHandle);
 
       backend.simulateLeave(targetBHandle);
+      handles = context.getTargetHandles();
+      expect(handles[0]).to.equal(targetAHandle);
+      expect(handles.length).to.be(1);
+    });
+
+    it('reset target handles on drop', () => {
+      const source = new NormalSource();
+      const sourceHandle = registry.addSource(Types.FOO, source);
+      const targetA = new NormalTarget();
+      const targetAHandle = registry.addTarget(Types.FOO, targetA);
+      const targetB = new NormalTarget();
+      const targetBHandle = registry.addTarget(Types.FOO, targetB);
+      let handles;
+
+      handles = context.getTargetHandles();
+      expect(handles.length).to.be(0);
+
+      backend.simulateBeginDrag(sourceHandle);
+      backend.simulateEnter(targetAHandle);
+      backend.simulateEnter(targetBHandle);
+      handles = context.getTargetHandles();
+      expect(handles[0]).to.equal(targetAHandle);
+      expect(handles[1]).to.equal(targetBHandle);
+      expect(handles.length).to.be(2);
+
+      backend.simulateDrop();
+      handles = context.getTargetHandles();
+      expect(handles.length).to.be(0);
+
+      backend.simulateEndDrag();
+      handles = context.getTargetHandles();
+      expect(handles.length).to.be(0);
+
+      backend.simulateBeginDrag(sourceHandle);
+      backend.simulateEnter(targetAHandle);
+      handles = context.getTargetHandles();
+      expect(handles[0]).to.equal(targetAHandle);
+      expect(handles.length).to.be(1);
+    });
+
+    it('reset target handles on endDrag', () => {
+      const source = new NormalSource();
+      const sourceHandle = registry.addSource(Types.FOO, source);
+      const targetA = new NormalTarget();
+      const targetAHandle = registry.addTarget(Types.FOO, targetA);
+      const targetB = new NormalTarget();
+      const targetBHandle = registry.addTarget(Types.FOO, targetB);
+      let handles;
+
+      handles = context.getTargetHandles();
+      expect(handles.length).to.be(0);
+
+      backend.simulateBeginDrag(sourceHandle);
+      backend.simulateEnter(targetAHandle);
+      backend.simulateEnter(targetBHandle);
+      handles = context.getTargetHandles();
+      expect(handles[0]).to.equal(targetAHandle);
+      expect(handles[1]).to.equal(targetBHandle);
+      expect(handles.length).to.be(2);
+
+      backend.simulateEndDrag();
+      handles = context.getTargetHandles();
+      expect(handles.length).to.be(0);
+
+      backend.simulateBeginDrag(sourceHandle);
+      backend.simulateEnter(targetAHandle);
       handles = context.getTargetHandles();
       expect(handles[0]).to.equal(targetAHandle);
       expect(handles.length).to.be(1);

--- a/modules/__tests__/DragDropManager-test.js
+++ b/modules/__tests__/DragDropManager-test.js
@@ -8,13 +8,11 @@ describe('DragDropManager', () => {
   let manager;
   let backend;
   let registry;
-  let context;
 
   beforeEach(() => {
     manager = new DragDropManager(TestBackend);
     backend = manager.getBackend();
     registry = manager.getRegistry();
-    context = manager.getContext();
   });
 
   describe('handler registration', () => {
@@ -153,54 +151,6 @@ describe('DragDropManager', () => {
 
       backend.simulateEndDrag();
       expect(source.recordedDropResult).to.equal(false);
-    });
-
-    it('removing an entered drop target midflight has the same effect as calling leave on it', () => {
-      const source = new NormalSource();
-      const sourceHandle = registry.addSource(Types.FOO, source);
-
-      const target = new NormalTarget();
-      const targetHandle = registry.addTarget(Types.FOO, target);
-
-      backend.simulateBeginDrag(sourceHandle);
-      backend.simulateEnter(targetHandle);
-      let handles = context.getTargetHandles();
-      expect(handles.length).to.be(1);
-      registry.removeTarget(targetHandle);
-      handles = context.getTargetHandles();
-      expect(handles.length).to.be(0);
-    });
-
-    it('enter() A, B, C, D and leave B keeps A active, but B, C and D inactive', () => {
-      const source = new NormalSource();
-      const sourceHandle = registry.addSource(Types.FOO, source);
-      const targetA = new NormalTarget();
-      const targetAHandle = registry.addTarget(Types.FOO, targetA);
-      const targetB = new NormalTarget();
-      const targetBHandle = registry.addTarget(Types.FOO, targetB);
-      const targetC = new NormalTarget();
-      const targetCHandle = registry.addTarget(Types.BAR, targetC);
-      const targetD = new NormalTarget();
-      const targetDHandle = registry.addTarget(Types.FOO, targetD);
-
-      backend.simulateBeginDrag(sourceHandle);
-      backend.simulateEnter(targetAHandle);
-      backend.simulateEnter(targetBHandle);
-      backend.simulateEnter(targetCHandle);
-      backend.simulateEnter(targetDHandle);
-
-      let handles = context.getTargetHandles();
-      expect(handles.length).to.be(4);
-      expect(handles[0]).to.equal(targetAHandle);
-      expect(handles[1]).to.equal(targetBHandle);
-      expect(handles[2]).to.equal(targetCHandle);
-      expect(handles[3]).to.equal(targetDHandle);
-
-      backend.simulateLeave(targetBHandle);
-
-      handles = context.getTargetHandles();
-      expect(handles[0]).to.equal(targetAHandle);
-      expect(handles.length).to.be(1);
     });
 
     it('throws in endDrag() if it is called outside a drag operation', () => {

--- a/modules/__tests__/DragDropManager-test.js
+++ b/modules/__tests__/DragDropManager-test.js
@@ -171,6 +171,38 @@ describe('DragDropManager', () => {
       expect(handles.length).to.be(0);
     });
 
+    it('enter() A, B, C, D and leave B keeps A active, but B, C and D inactive', () => {
+      const source = new NormalSource();
+      const sourceHandle = registry.addSource(Types.FOO, source);
+      const targetA = new NormalTarget();
+      const targetAHandle = registry.addTarget(Types.FOO, targetA);
+      const targetB = new NormalTarget();
+      const targetBHandle = registry.addTarget(Types.FOO, targetB);
+      const targetC = new NormalTarget();
+      const targetCHandle = registry.addTarget(Types.BAR, targetC);
+      const targetD = new NormalTarget();
+      const targetDHandle = registry.addTarget(Types.FOO, targetD);
+
+      backend.simulateBeginDrag(sourceHandle);
+      backend.simulateEnter(targetAHandle);
+      backend.simulateEnter(targetBHandle);
+      backend.simulateEnter(targetCHandle);
+      backend.simulateEnter(targetDHandle);
+
+      let handles = context.getTargetHandles();
+      expect(handles.length).to.be(4);
+      expect(handles[0]).to.equal(targetAHandle);
+      expect(handles[1]).to.equal(targetBHandle);
+      expect(handles[2]).to.equal(targetCHandle);
+      expect(handles[3]).to.equal(targetDHandle);
+
+      backend.simulateLeave(targetBHandle);
+
+      handles = context.getTargetHandles();
+      expect(handles[0]).to.equal(targetAHandle);
+      expect(handles.length).to.be(1);
+    });
+
     it('throws in endDrag() if it is called outside a drag operation', () => {
       const source = new NormalSource();
       const sourceHandle = registry.addSource(Types.FOO, source);

--- a/modules/__tests__/DragDropManager-test.js
+++ b/modules/__tests__/DragDropManager-test.js
@@ -62,203 +62,209 @@ describe('DragDropManager', () => {
   });
 
   describe('drag source and target contract', () => {
-    it('ignores beginDrag() if canDrag() returns false', () => {
-      const source = new NonDraggableSource();
-      const sourceHandle = registry.addSource(Types.FOO, source);
+    describe('beginDrag', () => {
+      it('ignores beginDrag() if canDrag() returns false', () => {
+        const source = new NonDraggableSource();
+        const sourceHandle = registry.addSource(Types.FOO, source);
 
-      backend.simulateBeginDrag(sourceHandle);
-      expect(source.didCallBeginDrag).to.equal(false);
+        backend.simulateBeginDrag(sourceHandle);
+        expect(source.didCallBeginDrag).to.equal(false);
+      });
+
+      it('throws if beginDrag() returns non-object', () => {
+        const source = new BadItemSource();
+        const sourceHandle = registry.addSource(Types.FOO, source);
+
+        expect(() => backend.simulateBeginDrag(sourceHandle)).to.throwError();
+      });
+
+      it('begins drag if canDrag() returns true', () => {
+        const source = new NormalSource();
+        const sourceHandle = registry.addSource(Types.FOO, source);
+
+        backend.simulateBeginDrag(sourceHandle);
+        expect(source.didCallBeginDrag).to.equal(true);
+      });
+
+      it('throws in beginDrag() if it is called twice during one operation', () => {
+        const source = new NormalSource();
+        const sourceHandle = registry.addSource(Types.FOO, source);
+
+        backend.simulateBeginDrag(sourceHandle);
+        expect(() => backend.simulateBeginDrag(sourceHandle)).to.throwError();
+      });
+
+      it('lets beginDrag() be called again in a next operation', () => {
+        const source = new NormalSource();
+        const sourceHandle = registry.addSource(Types.FOO, source);
+
+        backend.simulateBeginDrag(sourceHandle);
+        backend.simulateEndDrag(sourceHandle);
+
+        source.didCallBeginDrag = false;
+        expect(() => backend.simulateBeginDrag(sourceHandle)).to.not.throwError();
+        expect(source.didCallBeginDrag).to.equal(true);
+      });
     });
 
-    it('throws if beginDrag() returns non-object', () => {
-      const source = new BadItemSource();
-      const sourceHandle = registry.addSource(Types.FOO, source);
+    describe('drop() and endDrag()', () => {
+      it('endDrag() sees drop() return value as drop result if dropped on a target', () => {
+        const source = new NormalSource();
+        const sourceHandle = registry.addSource(Types.FOO, source);
+        const target = new NormalTarget();
+        const targetHandle = registry.addTarget(Types.FOO, target);
 
-      expect(() => backend.simulateBeginDrag(sourceHandle)).to.throwError();
+        backend.simulateBeginDrag(sourceHandle);
+        backend.simulateEnter(targetHandle);
+        backend.simulateDrop();
+        backend.simulateEndDrag();
+        expect(target.didCallDrop).to.equal(true);
+        expect(source.recordedDropResult.foo).to.equal('bar');
+      });
+
+      it('endDrag() sees true as drop result by default if dropped on a target', () => {
+        const source = new NormalSource();
+        const sourceHandle = registry.addSource(Types.FOO, source);
+        const target = new TargetWithNoDropResult();
+        const targetHandle = registry.addTarget(Types.FOO, target);
+
+        backend.simulateBeginDrag(sourceHandle);
+        backend.simulateEnter(targetHandle);
+        backend.simulateDrop();
+        backend.simulateEndDrag();
+        expect(source.recordedDropResult).to.equal(true);
+      });
+
+      it('endDrag() sees false as drop result if dropped outside a target', () => {
+        const source = new NormalSource();
+        const sourceHandle = registry.addSource(Types.FOO, source);
+
+        backend.simulateBeginDrag(sourceHandle);
+        backend.simulateEndDrag();
+        expect(source.recordedDropResult).to.equal(false);
+      });
+
+      it('calls endDrag even if source was unregistered', () => {
+        const source = new NormalSource();
+        const sourceHandle = registry.addSource(Types.FOO, source);
+
+        backend.simulateBeginDrag(sourceHandle);
+        registry.removeSource(sourceHandle);
+        expect(registry.getSource(sourceHandle)).to.equal(null);
+
+        backend.simulateEndDrag();
+        expect(source.recordedDropResult).to.equal(false);
+      });
+
+      it('throws in endDrag() if it is called outside a drag operation', () => {
+        const source = new NormalSource();
+        const sourceHandle = registry.addSource(Types.FOO, source);
+        expect(() => backend.simulateEndDrag(sourceHandle)).to.throwError();
+      });
+
+      it('ignores drop() if no drop targets entered', () => {
+        const source = new NormalSource();
+        const sourceHandle = registry.addSource(Types.FOO, source);
+
+        backend.simulateBeginDrag(sourceHandle);
+        backend.simulateDrop();
+        backend.simulateEndDrag();
+        expect(source.recordedDropResult).to.equal(false);
+      });
+
+      it('ignores drop() if drop targets entered and left', () => {
+        const source = new NormalSource();
+        const sourceHandle = registry.addSource(Types.FOO, source);
+        const targetA = new NormalTarget();
+        const targetAHandle = registry.addTarget(Types.FOO, targetA);
+        const targetB = new NormalTarget();
+        const targetBHandle = registry.addTarget(Types.FOO, targetB);
+
+        backend.simulateBeginDrag(sourceHandle);
+        backend.simulateEnter(targetAHandle);
+        backend.simulateEnter(targetBHandle);
+        backend.simulateLeave(targetBHandle);
+        backend.simulateLeave(targetAHandle);
+        backend.simulateDrop();
+        backend.simulateEndDrag();
+        expect(targetA.didCallDrop).to.equal(false);
+        expect(targetB.didCallDrop).to.equal(false);
+        expect(source.recordedDropResult).to.equal(false);
+      });
+
+      it('ignores drop() if canDrop() returns false', () => {
+        const source = new NormalSource();
+        const sourceHandle = registry.addSource(Types.FOO, source);
+        const target = new NonDroppableTarget();
+        const targetHandle = registry.addTarget(Types.FOO, target);
+
+        backend.simulateBeginDrag(sourceHandle);
+        backend.simulateEnter(targetHandle);
+        backend.simulateDrop();
+        expect(target.didCallDrop).to.equal(false);
+      });
+
+      it('ignores drop() if target has a different type', () => {
+        const source = new NormalSource();
+        const sourceHandle = registry.addSource(Types.FOO, source);
+        const target = new NormalTarget();
+        const targetHandle = registry.addTarget(Types.BAR, target);
+
+        backend.simulateBeginDrag(sourceHandle);
+        backend.simulateEnter(targetHandle);
+        backend.simulateDrop();
+        expect(target.didCallDrop).to.equal(false);
+      });
+
+      it('throws in drop() if it is called outside a drag operation', () => {
+        expect(() => backend.simulateDrop()).to.throwError();
+      });
+
+      it('throws in drop() if it returns something that is neither undefined nor an object', () => {
+        const source = new NormalSource();
+        const sourceHandle = registry.addSource(Types.FOO, source);
+        const target = new BadResultTarget();
+        const targetHandle = registry.addTarget(Types.FOO, target);
+
+        backend.simulateBeginDrag(sourceHandle);
+        backend.simulateEnter(targetHandle);
+        expect(() => backend.simulateDrop()).to.throwError();
+      });
     });
 
-    it('begins drag if canDrag() returns true', () => {
-      const source = new NormalSource();
-      const sourceHandle = registry.addSource(Types.FOO, source);
+    describe('enter() and leave()', () => {
+      it('throws in enter() if it is called outside a drag operation', () => {
+        const target = new NormalTarget();
+        const targetHandle = registry.addTarget(Types.BAR, target);
+        expect(() => backend.simulateEnter(targetHandle)).to.throwError();
+      });
 
-      backend.simulateBeginDrag(sourceHandle);
-      expect(source.didCallBeginDrag).to.equal(true);
-    });
+      it('throws in enter() if it is already in an entered target', () => {
+        const target = new NormalTarget();
+        const source = new NormalSource();
+        const sourceHandle = registry.addSource(Types.FOO, source);
+        const targetHandle = registry.addTarget(Types.BAR, target);
 
-    it('throws in beginDrag() if it is called twice during one operation', () => {
-      const source = new NormalSource();
-      const sourceHandle = registry.addSource(Types.FOO, source);
+        backend.simulateBeginDrag(sourceHandle);
+        backend.simulateEnter(targetHandle);
+        expect(() => backend.simulateEnter(targetHandle)).to.throwError();
+      });
 
-      backend.simulateBeginDrag(sourceHandle);
-      expect(() => backend.simulateBeginDrag(sourceHandle)).to.throwError();
-    });
+      it('throws in leave() if it is called outside a drag operation', () => {
+        const target = new NormalTarget();
+        const targetHandle = registry.addTarget(Types.BAR, target);
+        expect(() => backend.simulateLeave(targetHandle)).to.throwError();
+      });
 
-    it('lets beginDrag() be called again in a next operation', () => {
-      const source = new NormalSource();
-      const sourceHandle = registry.addSource(Types.FOO, source);
+      it('throws in leave() if it is not entered', () => {
+        const target = new NormalTarget();
+        const source = new NormalSource();
+        const sourceHandle = registry.addSource(Types.FOO, source);
+        const targetHandle = registry.addTarget(Types.BAR, target);
 
-      backend.simulateBeginDrag(sourceHandle);
-      backend.simulateEndDrag(sourceHandle);
-
-      source.didCallBeginDrag = false;
-      expect(() => backend.simulateBeginDrag(sourceHandle)).to.not.throwError();
-      expect(source.didCallBeginDrag).to.equal(true);
-    });
-
-    it('endDrag() sees drop() return value as drop result if dropped on a target', () => {
-      const source = new NormalSource();
-      const sourceHandle = registry.addSource(Types.FOO, source);
-      const target = new NormalTarget();
-      const targetHandle = registry.addTarget(Types.FOO, target);
-
-      backend.simulateBeginDrag(sourceHandle);
-      backend.simulateEnter(targetHandle);
-      backend.simulateDrop();
-      backend.simulateEndDrag();
-      expect(target.didCallDrop).to.equal(true);
-      expect(source.recordedDropResult.foo).to.equal('bar');
-    });
-
-    it('endDrag() sees true as drop result by default if dropped on a target', () => {
-      const source = new NormalSource();
-      const sourceHandle = registry.addSource(Types.FOO, source);
-      const target = new TargetWithNoDropResult();
-      const targetHandle = registry.addTarget(Types.FOO, target);
-
-      backend.simulateBeginDrag(sourceHandle);
-      backend.simulateEnter(targetHandle);
-      backend.simulateDrop();
-      backend.simulateEndDrag();
-      expect(source.recordedDropResult).to.equal(true);
-    });
-
-    it('endDrag() sees false as drop result if dropped outside a target', () => {
-      const source = new NormalSource();
-      const sourceHandle = registry.addSource(Types.FOO, source);
-
-      backend.simulateBeginDrag(sourceHandle);
-      backend.simulateEndDrag();
-      expect(source.recordedDropResult).to.equal(false);
-    });
-
-    it('calls endDrag even if source was unregistered', () => {
-      const source = new NormalSource();
-      const sourceHandle = registry.addSource(Types.FOO, source);
-
-      backend.simulateBeginDrag(sourceHandle);
-      registry.removeSource(sourceHandle);
-      expect(registry.getSource(sourceHandle)).to.equal(null);
-
-      backend.simulateEndDrag();
-      expect(source.recordedDropResult).to.equal(false);
-    });
-
-    it('throws in endDrag() if it is called outside a drag operation', () => {
-      const source = new NormalSource();
-      const sourceHandle = registry.addSource(Types.FOO, source);
-      expect(() => backend.simulateEndDrag(sourceHandle)).to.throwError();
-    });
-
-    it('throws in enter() if it is called outside a drag operation', () => {
-      const target = new NormalTarget();
-      const targetHandle = registry.addTarget(Types.BAR, target);
-      expect(() => backend.simulateEnter(targetHandle)).to.throwError();
-    });
-
-    it('throws in enter() if it is already in an entered target', () => {
-      const target = new NormalTarget();
-      const source = new NormalSource();
-      const sourceHandle = registry.addSource(Types.FOO, source);
-      const targetHandle = registry.addTarget(Types.BAR, target);
-
-      backend.simulateBeginDrag(sourceHandle);
-      backend.simulateEnter(targetHandle);
-      expect(() => backend.simulateEnter(targetHandle)).to.throwError();
-    });
-
-    it('throws in leave() if it is called outside a drag operation', () => {
-      const target = new NormalTarget();
-      const targetHandle = registry.addTarget(Types.BAR, target);
-      expect(() => backend.simulateLeave(targetHandle)).to.throwError();
-    });
-
-    it('throws in leave() if it is not entered', () => {
-      const target = new NormalTarget();
-      const source = new NormalSource();
-      const sourceHandle = registry.addSource(Types.FOO, source);
-      const targetHandle = registry.addTarget(Types.BAR, target);
-
-      backend.simulateBeginDrag(sourceHandle);
-      expect(() => backend.simulateLeave(targetHandle)).to.throwError();
-    });
-
-    it('ignores drop() if no drop targets entered', () => {
-      const source = new NormalSource();
-      const sourceHandle = registry.addSource(Types.FOO, source);
-
-      backend.simulateBeginDrag(sourceHandle);
-      backend.simulateDrop();
-      backend.simulateEndDrag();
-      expect(source.recordedDropResult).to.equal(false);
-    });
-
-    it('ignores drop() if drop targets entered and left', () => {
-      const source = new NormalSource();
-      const sourceHandle = registry.addSource(Types.FOO, source);
-      const targetA = new NormalTarget();
-      const targetAHandle = registry.addTarget(Types.FOO, targetA);
-      const targetB = new NormalTarget();
-      const targetBHandle = registry.addTarget(Types.FOO, targetB);
-
-      backend.simulateBeginDrag(sourceHandle);
-      backend.simulateEnter(targetAHandle);
-      backend.simulateEnter(targetBHandle);
-      backend.simulateLeave(targetBHandle);
-      backend.simulateLeave(targetAHandle);
-      backend.simulateDrop();
-      backend.simulateEndDrag();
-      expect(targetA.didCallDrop).to.equal(false);
-      expect(targetB.didCallDrop).to.equal(false);
-      expect(source.recordedDropResult).to.equal(false);
-    });
-
-    it('ignores drop() if canDrop() returns false', () => {
-      const source = new NormalSource();
-      const sourceHandle = registry.addSource(Types.FOO, source);
-      const target = new NonDroppableTarget();
-      const targetHandle = registry.addTarget(Types.FOO, target);
-
-      backend.simulateBeginDrag(sourceHandle);
-      backend.simulateEnter(targetHandle);
-      backend.simulateDrop();
-      expect(target.didCallDrop).to.equal(false);
-    });
-
-    it('ignores drop() if target has a different type', () => {
-      const source = new NormalSource();
-      const sourceHandle = registry.addSource(Types.FOO, source);
-      const target = new NormalTarget();
-      const targetHandle = registry.addTarget(Types.BAR, target);
-
-      backend.simulateBeginDrag(sourceHandle);
-      backend.simulateEnter(targetHandle);
-      backend.simulateDrop();
-      expect(target.didCallDrop).to.equal(false);
-    });
-
-    it('throws in drop() if it is called outside a drag operation', () => {
-      expect(() => backend.simulateDrop()).to.throwError();
-    });
-
-    it('throws in drop() if it returns something that is neither undefined nor an object', () => {
-      const source = new NormalSource();
-      const sourceHandle = registry.addSource(Types.FOO, source);
-      const target = new BadResultTarget();
-      const targetHandle = registry.addTarget(Types.FOO, target);
-
-      backend.simulateBeginDrag(sourceHandle);
-      backend.simulateEnter(targetHandle);
-      expect(() => backend.simulateDrop()).to.throwError();
+        backend.simulateBeginDrag(sourceHandle);
+        expect(() => backend.simulateLeave(targetHandle)).to.throwError();
+      });
     });
   });
 });

--- a/modules/__tests__/DragDropManager-test.js
+++ b/modules/__tests__/DragDropManager-test.js
@@ -62,7 +62,7 @@ describe('DragDropManager', () => {
   });
 
   describe('drag source and target contract', () => {
-    describe('beginDrag', () => {
+    describe('beginDrag() and canDrag()', () => {
       it('ignores beginDrag() if canDrag() returns false', () => {
         const source = new NonDraggableSource();
         const sourceHandle = registry.addSource(Types.FOO, source);
@@ -107,7 +107,7 @@ describe('DragDropManager', () => {
       });
     });
 
-    describe('drop() and endDrag()', () => {
+    describe('drop(), canDrop() and endDrag()', () => {
       it('endDrag() sees drop() return value as drop result if dropped on a target', () => {
         const source = new NormalSource();
         const sourceHandle = registry.addSource(Types.FOO, source);

--- a/modules/__tests__/DragDropManager-test.js
+++ b/modules/__tests__/DragDropManager-test.js
@@ -215,6 +215,17 @@ describe('DragDropManager', () => {
       expect(() => backend.simulateEnter(targetHandle)).to.throwError();
     });
 
+    it('throws in enter() if it is already in an entered target', () => {
+      const target = new NormalTarget();
+      const source = new NormalSource();
+      const sourceHandle = registry.addSource(Types.FOO, source);
+      const targetHandle = registry.addTarget(Types.BAR, target);
+
+      backend.simulateBeginDrag(sourceHandle);
+      backend.simulateEnter(targetHandle);
+      expect(() => backend.simulateEnter(targetHandle)).to.throwError();
+    });
+
     it('throws in leave() if it is called outside a drag operation', () => {
       const target = new NormalTarget();
       const targetHandle = registry.addTarget(Types.BAR, target);

--- a/modules/__tests__/DragDropManager-test.js
+++ b/modules/__tests__/DragDropManager-test.js
@@ -232,6 +232,16 @@ describe('DragDropManager', () => {
       expect(() => backend.simulateLeave(targetHandle)).to.throwError();
     });
 
+    it('throws in leave() if it is not entered', () => {
+      const target = new NormalTarget();
+      const source = new NormalSource();
+      const sourceHandle = registry.addSource(Types.FOO, source);
+      const targetHandle = registry.addTarget(Types.BAR, target);
+
+      backend.simulateBeginDrag(sourceHandle);
+      expect(() => backend.simulateLeave(targetHandle)).to.throwError();
+    });
+
     it('ignores drop() if no drop targets entered', () => {
       const source = new NormalSource();
       const sourceHandle = registry.addSource(Types.FOO, source);

--- a/modules/__tests__/DragDropManager-test.js
+++ b/modules/__tests__/DragDropManager-test.js
@@ -8,11 +8,13 @@ describe('DragDropManager', () => {
   let manager;
   let backend;
   let registry;
+  let context;
 
   beforeEach(() => {
     manager = new DragDropManager(TestBackend);
     backend = manager.getBackend();
     registry = manager.getRegistry();
+    context = manager.getContext();
   });
 
   describe('handler registration', () => {
@@ -151,6 +153,22 @@ describe('DragDropManager', () => {
 
       backend.simulateEndDrag();
       expect(source.recordedDropResult).to.equal(false);
+    });
+
+    it('removing an entered drop target midflight has the same effect as calling leave on it', () => {
+      const source = new NormalSource();
+      const sourceHandle = registry.addSource(Types.FOO, source);
+
+      const target = new NormalTarget();
+      const targetHandle = registry.addTarget(Types.FOO, target);
+
+      backend.simulateBeginDrag(sourceHandle);
+      backend.simulateEnter(targetHandle);
+      let handles = context.getTargetHandles();
+      expect(handles.length).to.be(1);
+      registry.removeTarget(targetHandle);
+      handles = context.getTargetHandles();
+      expect(handles.length).to.be(0);
     });
 
     it('throws in endDrag() if it is called outside a drag operation', () => {

--- a/modules/__tests__/targets.js
+++ b/modules/__tests__/targets.js
@@ -27,10 +27,30 @@ export class NonDroppableTarget extends DropTarget {
 }
 
 export class TargetWithNoDropResult extends DropTarget {
+  constructor() {
+    this.didCallDrop = false;
+  }
+
+  drop() {
+    this.didCallDrop = true;
+  }
 }
 
 export class BadResultTarget extends DropTarget {
   drop() {
     return 42;
+  }
+}
+
+export class TransformResultTarget extends DropTarget {
+  constructor(transform) {
+    this.transform = transform;
+    this.didCallDrop = false;
+  }
+
+  drop(context) {
+    this.didCallDrop = true;
+    const dropResult = context.getDropResult();
+    return this.transform(dropResult);
   }
 }

--- a/modules/actions/DragDropActions.js
+++ b/modules/actions/DragDropActions.js
@@ -67,26 +67,26 @@ export default class DragDropActions extends Actions {
       'Cannot call drop while not dragging.'
     );
 
-    const targetHandles = context.getTargetHandles();
-    if (!targetHandles.length) {
-      return;
-    }
-    const targetHandle = targetHandles[targetHandles.length - 1];
-    if (!context.canDrop(targetHandle)) {
-      return;
-    }
+    const targetHandles = context
+      .getTargetHandles()
+      .filter(context.canDrop, context);
 
-    const target = registry.getTarget(targetHandle);
-    let dropResult = target.drop(context, targetHandle);
-    invariant(
-      typeof dropResult === 'undefined' || isObject(dropResult),
-      'Drop result must either be an object or undefined.'
-    );
-    if (typeof dropResult === 'undefined') {
-      dropResult = true;
-    }
+    targetHandles.reverse();
+    targetHandles.forEach((targetHandle, index) => {
+      const target = registry.getTarget(targetHandle);
 
-    return { dropResult };
+      let dropResult = target.drop(context, targetHandle);
+      invariant(
+        typeof dropResult === 'undefined' || isObject(dropResult),
+        'Drop result must either be an object or undefined.'
+      );
+      if (typeof dropResult === 'undefined') {
+        dropResult = index === 0 ? true : context.getDropResult();
+      }
+
+      const actionId = this.getActionIds().drop;
+      this.dispatch(actionId, { dropResult });
+    });
   }
 
   endDrag() {

--- a/modules/actions/RegistryActions.js
+++ b/modules/actions/RegistryActions.js
@@ -1,19 +1,19 @@
 import { Actions } from 'flummox'
 
 export default class RegistryActions extends Actions {
-  addSource({ sourceHandle }) {
+  addSource(sourceHandle) {
     return { sourceHandle };
   }
 
-  addTarget({ targetHandle }) {
+  addTarget(targetHandle) {
     return { targetHandle };
   }
 
-  removeSource({ sourceHandle }) {
+  removeSource(sourceHandle) {
     return { sourceHandle };
   }
 
-  removeTarget({ targetHandle }) {
+  removeTarget(targetHandle) {
     return { targetHandle };
   }
 }


### PR DESCRIPTION
Continuation of #3.

- [x] Add test verifying `enter` throws with an already `enter`ed drop target
- [x] Add test verifying `leave` throws with a non-`enter`ed drop target
- [x] Add test verifying `enter` A, B, C, D and `leave` B keeps A active, but B, C and D inactive
- [x] Add test verifying that removing an `enter`ed drop target midflight has the same effect as calling `leave` on it
- [x] Add test verifying both `drop` and `endDrag` completely clear active drop targets
- [x] Add and test `context.isOver(dropTarget, shallow=false)` that tells whether we have entered the drop target. With `shallow=true`, returns `true` *only* if that drop target is innermost entered one.
- [x] Change `drop` implementation that, instead of simply choosing innermost target, will run `drop` on each nested active target, from the innermost to the outermost. It will skip drop targets for which `context.canDrop` returns false. Each target will be able to access previous' result in `context.getDropResult()` and learn if there *was* a previous one by reading `context.didDrop()`. Each will be able to either return `undefined` (means don't touch drop result) or a different object (means replace drop result with the one returned from `drop`). Test that.