### PR TITLE
fix symbol usage

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,5 @@
 {
   "stage": 0,
-  "loose": ["es6.modules", "es6.classes"]
+  "loose": ["es6.modules", "es6.classes"],
+  "optional": ["es6.spec.symbols"]
 }


### PR DESCRIPTION
re: #18. According to [this Babel doc](https://babeljs.io/docs/advanced/transformers/es6/spec-symbols/), it seems that the "optional" field is needed to include ```Symbol```. I think the other option would be to include the Babel polyfill, but I'm not sure how to pass that option to Mocha.