### PR TITLE
Adding filterTargets option to DragDropMonitor.isOverTarget.

### DIFF
--- a/src/DragDropMonitor.js
+++ b/src/DragDropMonitor.js
@@ -99,7 +99,8 @@ export default class DragDropMonitor {
   }
 
   isOverTarget(targetId, {
-    shallow = false
+    shallow = false,
+    filterTargets = false
   }: options = {}) {
     if (!this.isDragging()) {
       return false;
@@ -111,9 +112,16 @@ export default class DragDropMonitor {
       return false;
     }
 
-    const targetIds = this.getTargetIds();
+    let targetIds = this.getTargetIds();
     if (!targetIds.length) {
       return false;
+    }
+
+    if (filterTargets) {
+      targetIds = targetIds.filter(id => {
+        const type = this.registry.getTargetType(id);
+        return matchesType(type, draggedItemType);
+      });
     }
 
     const index = targetIds.indexOf(targetId);

--- a/src/reducers/dirtyHandlerIds.js
+++ b/src/reducers/dirtyHandlerIds.js
@@ -9,7 +9,7 @@ const ALL = [];
 export default function dirtyHandlerIds(state = NONE, action, dragOperation) {
   switch (action.type) {
   case HOVER:
-    break;
+    return ALL;
   case ADD_SOURCE:
   case ADD_TARGET:
   case REMOVE_TARGET:
@@ -22,40 +22,6 @@ export default function dirtyHandlerIds(state = NONE, action, dragOperation) {
   default:
     return ALL;
   }
-
-  const { targetIds } = action;
-  const { targetIds: prevTargetIds } = dragOperation;
-  const dirtyHandlerIds = xor(targetIds, prevTargetIds);
-
-  let didChange = false;
-  if (dirtyHandlerIds.length === 0) {
-    for (let i = 0; i < targetIds.length; i++) {
-      if (targetIds[i] !== prevTargetIds[i]) {
-        didChange = true;
-        break;
-      }
-    }
-  } else {
-    didChange = true;
-  }
-
-  if (!didChange) {
-    return NONE;
-  }
-
-  const prevInnermostTargetId = prevTargetIds[prevTargetIds.length - 1];
-  const innermostTargetId = targetIds[targetIds.length - 1];
-
-  if (prevInnermostTargetId !== innermostTargetId) {
-    if (prevInnermostTargetId) {
-      dirtyHandlerIds.push(prevInnermostTargetId);
-    }
-    if (innermostTargetId) {
-      dirtyHandlerIds.push(innermostTargetId);
-    }
-  }
-
-  return dirtyHandlerIds;
 }
 
 export function areDirty(state, handlerIds) {


### PR DESCRIPTION
Given target A that accepts type P.
Given target B that accepts type Q.
Given target C that accepts type P.
Given C is inside of B, and B is inside of A.
Given drag source with type P.
When drag source is over B, there is no way to know that A is the top-most target that matches the drag source type.

This PR proposes an option called `filterTarget`. When true, the function `isOverTarget` will filter out targets that don't match the dragged item type. Then, we can use the shallow option to return the top-most target that matches the source type.

This PR does not work correctly with function `dirtyHandlerIds`. The optimizations at the end of that function do not use types. It would be great if we could pass an option to that function to filter out by type. 

For our use case, returning `ALL` for case `HOVER` works well. I don't think we'll need the code at the bottom of the `dirtyHandlerIds` function.

I don't expect the PR to be accepted as-is. It would be great to get some feedback on these changes. Ideally, we would pass a parameter to `dirtyHandlerIds` so it takes types into account. I'm not sure how we would do that.