### PR TITLE
Fix for bug #24 DragDropMonitor failes to notify subscribeToStateChange subscribers in some cases

### DIFF
--- a/src/DragDropMonitor.js
+++ b/src/DragDropMonitor.js
@@ -23,9 +23,21 @@ export default class DragDropMonitor {
       'handlerIds, when specified, must be an array of strings.'
     );
 
+    let prevStateId = this.store.getState().stateId;
     const handleChange = () => {
-      if (areDirty(this.store.getState().dirtyHandlerIds, handlerIds)) {
-        listener();
+      const state = this.store.getState();
+      const currentStateId = state.stateId;
+      try {
+        const canSkipListener = currentStateId === prevStateId || (
+          currentStateId === prevStateId + 1 &&
+          !areDirty(state.dirtyHandlerIds, handlerIds)
+        )
+
+        if (!canSkipListener) {
+          listener();
+        }
+      } finally {
+        prevStateId = currentStateId;
       }
     };
 

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -2,12 +2,14 @@ import { default as dragOffset } from './dragOffset';
 import { default as dragOperation } from './dragOperation';
 import { default as refCount } from './refCount';
 import { default as dirtyHandlerIds } from './dirtyHandlerIds';
+import { default as stateId } from './stateId';
 
 export default function (state = {}, action) {
   return {
     dirtyHandlerIds: dirtyHandlerIds(state.dirtyHandlerIds, action, state.dragOperation),
     dragOffset: dragOffset(state.dragOffset, action),
     refCount: refCount(state.refCount, action),
-    dragOperation: dragOperation(state.dragOperation, action)
+    dragOperation: dragOperation(state.dragOperation, action),
+    stateId: stateId(state.stateId)
   };
 }

--- a/src/reducers/stateId.js
+++ b/src/reducers/stateId.js
@@ -1,0 +1,3 @@
+export default function stateId(state = 0) {
+    return state + 1;
+}

--- a/test/DragDropMonitor.spec.js
+++ b/test/DragDropMonitor.spec.js
@@ -463,6 +463,29 @@ describe('DragDropMonitor', () => {
       expect(raisedChange).to.equal(false);
     });
 
+    it('raises global change event on beginDrag(), even if redux did not notify us for all stat updates.', (done) => {
+      const source = new NormalSource();
+      const sourceId = registry.addSource(Types.FOO, source);
+      const target = new NormalTarget()
+
+      let notified = false;
+      monitor.subscribeToStateChange(
+          () => {
+            if (!notified)
+            {
+              notified = true;
+              // Add target will send an action to redux, which will trigger a new state update.
+              // The redux behaviour then is to send only the latest state to the subscribers
+              // which means that the subscription below will not receive this state.
+              registry.addTarget(Types.FOO, target)
+            }
+          });
+
+      monitor.subscribeToStateChange(
+          () => { done()});
+      backend.simulateBeginDrag([sourceId]);
+    });
+
     it('throws when passing clientOffset without getSourceClientOffset', () => {
       const source = new NormalSource();
       const sourceId = registry.addSource(Types.FOO, source);


### PR DESCRIPTION
Added stateId which is increased by one each time an action is dispatched to the store.

Make sure that SubscribeToState change always calls listner() if no notification was received with the previous state, as the areDirty(...) code will not work in that case.