### PR TITLE
Delete non-matching types from targetIds.

### DIFF
--- a/src/actions/dragDrop.js
+++ b/src/actions/dragDrop.js
@@ -95,6 +95,18 @@ export function hover(targetIds, { clientOffset = null } = {}) {
   );
 
   const draggedItemType = monitor.getItemType();
+
+  // Remove those targetIds that don't match the targetType.  This
+  // fixes shallow isOver which would only be non-shallow because of
+  // non-matching targets.
+  for (let i = targetIds.length - 1; i >= 0; i--) {
+    const targetId = targetIds[i];
+    const targetType = registry.getTargetType(targetId);
+    if (!matchesType(targetType, draggedItemType)) {
+      targetIds.splice(i, 1);
+    }
+  }
+
   for (let i = 0; i < targetIds.length; i++) {
     const targetId = targetIds[i];
     invariant(
@@ -108,10 +120,7 @@ export function hover(targetIds, { clientOffset = null } = {}) {
       'Expected targetIds to be registered.'
     );
 
-    const targetType = registry.getTargetType(targetId);
-    if (matchesType(targetType, draggedItemType)) {
-      target.hover(monitor, targetId);
-    }
+    target.hover(monitor, targetId);
   }
 
   return {

--- a/src/actions/dragDrop.js
+++ b/src/actions/dragDrop.js
@@ -94,6 +94,21 @@ export function hover(targetIds, { clientOffset = null } = {}) {
     'Cannot call hover after drop.'
   );
 
+  // First check invariants.
+  for (let i = 0; i < targetIds.length; i++) {
+    const targetId = targetIds[i];
+    invariant(
+      targetIds.lastIndexOf(targetId) === i,
+      'Expected targetIds to be unique in the passed array.'
+    );
+
+    const target = registry.getTarget(targetId);
+    invariant(
+      target,
+      'Expected targetIds to be registered.'
+    );
+  }
+
   const draggedItemType = monitor.getItemType();
 
   // Remove those targetIds that don't match the targetType.  This
@@ -107,19 +122,10 @@ export function hover(targetIds, { clientOffset = null } = {}) {
     }
   }
 
+  // Finally call hover on all matching targets.
   for (let i = 0; i < targetIds.length; i++) {
     const targetId = targetIds[i];
-    invariant(
-      targetIds.lastIndexOf(targetId) === i,
-      'Expected targetIds to be unique in the passed array.'
-    );
-
     const target = registry.getTarget(targetId);
-    invariant(
-      target,
-      'Expected targetIds to be registered.'
-    );
-
     target.hover(monitor, targetId);
   }
 

--- a/test/DragDropManager.spec.js
+++ b/test/DragDropManager.spec.js
@@ -622,6 +622,18 @@ describe('DragDropManager', () => {
         expect(() => backend.simulateHover([targetAId, targetBId, targetAId])).to.throwError();
       });
 
+      it('throws in hover() if it contains the same target twice (even if wrong type)', () => {
+        const source = new NormalSource();
+        const sourceId = registry.addSource(Types.FOO, source);
+        const targetA = new NormalTarget();
+        const targetAId = registry.addTarget(Types.BAR, targetA);
+        const targetB = new NormalTarget();
+        const targetBId = registry.addTarget(Types.BAR, targetB);
+
+        backend.simulateBeginDrag([sourceId]);
+        expect(() => backend.simulateHover([targetAId, targetBId, targetAId])).to.throwError();
+      });
+
       it('throws in hover() if it is called with a non-array', () => {
         const source = new NormalSource();
         const sourceId = registry.addSource(Types.FOO, source);

--- a/test/DragDropManager.spec.js
+++ b/test/DragDropManager.spec.js
@@ -612,7 +612,7 @@ describe('DragDropManager', () => {
 
       it('throws in hover() if it contains the same target twice', () => {
         const source = new NormalSource();
-        const sourceId = registry.addSource(Types.FOO, source);
+        const sourceId = registry.addSource(Types.BAR, source);
         const targetA = new NormalTarget();
         const targetAId = registry.addTarget(Types.BAR, targetA);
         const targetB = new NormalTarget();

--- a/test/DragDropMonitor.spec.js
+++ b/test/DragDropMonitor.spec.js
@@ -1292,27 +1292,25 @@ describe('DragDropMonitor', () => {
 
       backend.simulateHover([targetAId, targetBId, targetCId]);
       handles = monitor.getTargetIds();
-      expect(handles.length).to.be(3);
+      expect(handles.length).to.be(2);
       expect(handles[0]).to.equal(targetAId);
       expect(monitor.isOverTarget(targetAId)).to.equal(true);
       expect(monitor.isOverTarget(targetAId, { shallow: true })).to.equal(false);
       expect(handles[1]).to.equal(targetBId);
       expect(monitor.isOverTarget(targetBId)).to.equal(true);
-      expect(monitor.isOverTarget(targetBId, { shallow: true })).to.equal(false);
-      expect(handles[2]).to.equal(targetCId);
+      expect(monitor.isOverTarget(targetBId, { shallow: true })).to.equal(true);
       expect(monitor.isOverTarget(targetCId)).to.equal(false);
       expect(monitor.isOverTarget(targetCId, { shallow: true })).to.equal(false);
 
       backend.simulateHover([targetCId, targetBId, targetAId]);
       handles = monitor.getTargetIds();
-      expect(handles.length).to.be(3);
-      expect(handles[0]).to.equal(targetCId);
+      expect(handles.length).to.be(2);
       expect(monitor.isOverTarget(targetCId)).to.equal(false);
       expect(monitor.isOverTarget(targetCId, { shallow: true })).to.equal(false);
-      expect(handles[1]).to.equal(targetBId);
+      expect(handles[0]).to.equal(targetBId);
       expect(monitor.isOverTarget(targetBId)).to.equal(true);
       expect(monitor.isOverTarget(targetBId, { shallow: true })).to.equal(false);
-      expect(handles[2]).to.equal(targetAId);
+      expect(handles[1]).to.equal(targetAId);
       expect(monitor.isOverTarget(targetAId)).to.equal(true);
       expect(monitor.isOverTarget(targetAId, { shallow: true })).to.equal(true);
 


### PR DESCRIPTION
Edit: I see this might be a duplicate of #22.  Also, see screenshots below.

Hi @gaearon, great library.  I ran into an issue today.

Here's the scenario.  I have a list with Foos and Bars.  All Foos come before all Bars.

```
╭─────────╮
│Foo 1    │
│Foo 2    │
│Foo 3    │
│Bar 1    │
│Bar 2    │
│Bar 3    │
│         │
│         │
│         │
└─────────┘
```

Both Foos and Bars are DropTargets and DragSources -- you can drag and drop them to reorder them among their own kind.

```javascript
Foo = DragSource("foo", ...)(Foo);
Foo = DropTarget("foo", ...)(Foo);
Bar = DropSource("bar", ...)(Bar);
Bar = DropTarget("bar", ...)(Bar);
```

Additionally, you can drag a Foo from another list to this one.  If you drag it on top of a Foo, it is added to the list and does normal reorder behavior.  However, you can also drag it into the list, below the Foos and Bars, in order to quickly add it to the end of the Foos list.

```
╭─────────╮                                    ╭─────────╮
│Foo 1    │                                    │Foo 1    │
│Foo 2    │                                    │Foo 2    │
│Foo 3    │                                    │Foo 3    │
│Bar 1    │                    →               │Foo 4    │
│Bar 2    │                 becomes            │Bar 1    │
│Bar 3    │                                    │Bar 2    │
│         │                                    │Bar 3    │
│         │ ← drop "Foo 4" from elsewhere here │         │
│         │                                    │         │
└─────────┘                                    └─────────┘

```

In order to accomplish this, FooBarList is a DropTarget.

```javascript
FooBarList = DropTarget("foo", ...)(FooBarList);
```

This is _mostly_ working... basically I'm checking `isOver({ shallow: true })` in FooBarList.

Dragging a Foo into the Foos of the list works fine.  Dragging it into the whitespace is also fine because of FooBarList's shallow handling.  And now I want it so that when you drag a Foo over a Bar it behaves as if dragged it in the whitespace.  But because Bar is a DropTarget, dragging a Foo over a Bar is causing the `isOver({ shallow: true })` in FooBarList to return false.

This is because the shallow check works by checking that the given targetId is the last of the dragOperation's targetIds -- and the targetIds passed to the action aren't filtered by type, except when deciding when to call `target.hover`.

```javascript
// DragDropMonitor.js:131
    const index = targetIds.indexOf(targetId);
    if (shallow) {
      return index === targetIds.length - 1;
    } else {
      return index > -1;
    }
```

My suggestion: Since Bar is not a valid DropTarget, it shouldn't be considered when checking shallow isOver for FooBarList.  In general, *`isOver({ shallow: true })` should only check matching target types*.

This patch is based on my 10-minute understanding of dnd-core.  It fixes my issue, but breaks 32 tests.  And naturally I wanted to get feedback before changing any tests!