### PR TITLE
Implement wildcard source type

### DIFF
--- a/src/HandlerRegistry.js
+++ b/src/HandlerRegistry.js
@@ -1,6 +1,8 @@
 import invariant from 'invariant';
 import isArray from 'lodash/isArray';
 import getNextUniqueId from './utils/getNextUniqueId';
+import isValidSourceType from './utils/isValidSourceType';
+import isValidTargetType from './utils/isValidTargetType';
 import { addSource, addTarget, removeSource, removeTarget } from './actions/registry';
 import asap from 'asap';
 
@@ -19,20 +21,6 @@ function validateTargetContract(target) {
   invariant(typeof target.canDrop === 'function', 'Expected canDrop to be a function.');
   invariant(typeof target.hover === 'function', 'Expected hover to be a function.');
   invariant(typeof target.drop === 'function', 'Expected beginDrag to be a function.');
-}
-
-function validateType(type, allowArray) {
-  if (allowArray && isArray(type)) {
-    type.forEach(t => validateType(t, false));
-    return;
-  }
-
-  invariant(
-    typeof type === 'string' || typeof type === 'symbol',
-    allowArray ?
-      'Type can only be a string, a symbol, or an array of either.' :
-      'Type can only be a string or a symbol.'
-  );
 }
 
 function getNextHandlerId(role) {
@@ -70,7 +58,10 @@ export default class HandlerRegistry {
   }
 
   addSource(type, source) {
-    validateType(type);
+    invariant(
+      isValidSourceType(type),
+        'Source type can only be a string, a symbol, a boolean, or an array thereof.'
+    );
     validateSourceContract(source);
 
     const sourceId = this.addHandler(HandlerRoles.SOURCE, type, source);
@@ -79,7 +70,10 @@ export default class HandlerRegistry {
   }
 
   addTarget(type, target) {
-    validateType(type, true);
+    invariant(
+      isValidTargetType(type),
+        'Target type can only be a string or a symbol.'
+    );
     validateTargetContract(target);
 
     const targetId = this.addHandler(HandlerRoles.TARGET, type, target);

--- a/src/index.js
+++ b/src/index.js
@@ -2,3 +2,5 @@ export { default as DragDropManager } from './DragDropManager';
 export { default as DragSource } from './DragSource';
 export { default as DropTarget } from './DropTarget';
 export { default as createTestBackend } from './backends/createTestBackend';
+export { default as isValidTargetType } from './utils/isValidTargetType';
+export { default as isValidSourceType } from './utils/isValidSourceType';

--- a/src/utils/isValidSourceType.js
+++ b/src/utils/isValidSourceType.js
@@ -1,0 +1,5 @@
+export default function isValidSourceType(sourceType) {
+  const type = typeof sourceType;
+  return type === 'string' || type === 'symbol';
+}
+

--- a/src/utils/isValidTargetType.js
+++ b/src/utils/isValidTargetType.js
@@ -1,0 +1,18 @@
+import isArray from 'lodash/isArray';
+
+export default function isValidTargetType(targetType) {
+  if (isArray(targetType)) {
+    for (let n = 0, len = targetType.length; n < len; n++) {
+      const type = typeof targetType[n];
+      if (type !== 'boolean' && type !== 'string' && type !== 'symbol') {
+        return false;
+      }
+    }
+
+    return true;
+  } else {
+    const type = typeof targetType;
+    return type === 'boolean' || type === 'string' || type === 'symbol';
+  }
+}
+

--- a/src/utils/matchesType.js
+++ b/src/utils/matchesType.js
@@ -2,8 +2,8 @@ import isArray from 'lodash/isArray';
 
 export default function matchesType(targetType, draggedItemType) {
   if (isArray(targetType)) {
-    return targetType.some(t => t === draggedItemType);
+    return targetType.some(t => t === true || t === draggedItemType);
   } else {
-    return targetType === draggedItemType;
+    return targetType === true || targetType === draggedItemType;
   }
 }

--- a/test/API.spec.js
+++ b/test/API.spec.js
@@ -1,0 +1,16 @@
+import expect from 'expect.js';
+import { isValidSourceType } from '../src';
+import { isValidTargetType } from '../src';
+
+describe('API', () => {
+  describe('utils', (done) => {
+    it('exposes isValidSourceType', () => {
+      expect(isValidSourceType).to.be.a("function");
+    });
+
+    it('exposes isValidTargetType', () => {
+      expect(isValidTargetType).to.be.a("function");
+    });
+  });
+});
+

--- a/test/types.js
+++ b/test/types.js
@@ -1,3 +1,5 @@
 export const FOO = 'FOO';
 export const BAR = 'BAR';
 export const BAZ = 'BAZ';
+export const WILDCARD = true;
+export const NIL = false;


### PR DESCRIPTION
New feature for gaearon/react-dnd#432

I don't want to "rock the boat" here, so let me know if something doesn't make sense :).

A couple of notes:
* I created and exposed `isValidTargetType` and `isValidSourceType`
* I added API.spec.js to test that they're exposed since they're used in react-dnd
* I sprinkled `Types.WILDCARD` and `Types.NIL` a bit throughout the tests

react-dnd pull request incoming